### PR TITLE
Add option to hide table header

### DIFF
--- a/MMM-PublicTransportBerlin.js
+++ b/MMM-PublicTransportBerlin.js
@@ -15,8 +15,8 @@ Module.register("MMM-PublicTransportBerlin", {
         departureMinutes: 30,               // For how many minutes should departures be shown?
         showColoredLineSymbols: true,       // Want colored line symbols?
         useColorForRealtimeInfo: true,      // Want colored real time information (delay, early)?
-        showTableHeadersAsSymbols: true,    // Table Headers as symbols or written?
         showTableHeaders: true,             // Show table headers?
+        showTableHeadersAsSymbols: true,    // Table Headers as symbols or written?
         maxUnreachableDepartures: 3,        // How many unreachable departures should be shown?
         maxReachableDepartures: 7,          // How many reachable departures should be shown?
         fadeUnreachableDepartures: true,
@@ -73,7 +73,7 @@ Module.register("MMM-PublicTransportBerlin", {
 
         // Cell for departure time
         let headerTime = document.createElement("td");
-        if (this.config.showTableHeadersAsSymbols || this.config.showTableHeadersAs === 'symbol') {
+        if (this.config.showTableHeadersAsSymbols) {
             headerTime.className = "centeredTd";
             let timeIcon = document.createElement("span");
             timeIcon.className = "fa fa-clock-o";
@@ -91,7 +91,7 @@ Module.register("MMM-PublicTransportBerlin", {
 
         // Cell for line symbol
         let headerLine = document.createElement("td");
-        if (this.config.showTableHeadersAsSymbols || this.config.showTableHeadersAs === 'symbol') {
+        if (this.config.showTableHeadersAsSymbols) {
             headerLine.className = "centeredTd";
             let lineIcon = document.createElement("span");
             lineIcon.className = "fa fa-tag";
@@ -104,7 +104,7 @@ Module.register("MMM-PublicTransportBerlin", {
 
         // Cell for direction
         let headerDirection = document.createElement("td");
-        if (this.config.showTableHeadersAsSymbols || this.config.showTableHeadersAs === 'symbol') {
+        if (this.config.showTableHeadersAsSymbols) {
             headerDirection.className = "centeredTd";
             let directionIcon = document.createElement("span");
             directionIcon.className = "fa fa-exchange";

--- a/MMM-PublicTransportBerlin.js
+++ b/MMM-PublicTransportBerlin.js
@@ -16,6 +16,7 @@ Module.register("MMM-PublicTransportBerlin", {
         showColoredLineSymbols: true,       // Want colored line symbols?
         useColorForRealtimeInfo: true,      // Want colored real time information (delay, early)?
         showTableHeadersAsSymbols: true,    // Table Headers as symbols or written?
+        showTableHeadersAs: 'symbol',        // Table headers as symbols, text or hidden
         maxUnreachableDepartures: 3,        // How many unreachable departures should be shown?
         maxReachableDepartures: 7,          // How many reachable departures should be shown?
         fadeUnreachableDepartures: true,
@@ -72,12 +73,13 @@ Module.register("MMM-PublicTransportBerlin", {
 
         // Cell for departure time
         let headerTime = document.createElement("td");
-
-        if (this.config.showTableHeadersAsSymbols) {
+        if (this.config.showTableHeadersAsSymbols || this.config.showTableHeadersAs === 'symbol') {
             headerTime.className = "centeredTd";
             let timeIcon = document.createElement("span");
             timeIcon.className = "fa fa-clock-o";
             headerTime.appendChild(timeIcon);
+        } else if (this.config.showTableHeadersAs==='hidden') {
+            headerTime.innerHTML = "";
         } else {
             headerTime.innerHTML = "Abfahrt";
         }
@@ -91,12 +93,13 @@ Module.register("MMM-PublicTransportBerlin", {
 
         // Cell for line symbol
         let headerLine = document.createElement("td");
-
-        if (this.config.showTableHeadersAsSymbols) {
+        if (this.config.showTableHeadersAsSymbols || this.config.showTableHeadersAs === 'symbol') {
             headerLine.className = "centeredTd";
             let lineIcon = document.createElement("span");
             lineIcon.className = "fa fa-tag";
             headerLine.appendChild(lineIcon);
+        } else if (this.config.showTableHeadersAs==='hidden') {
+            headerLine.innerHTML = "";
         } else {
             headerLine.innerHTML = "Linie";
         }
@@ -105,11 +108,13 @@ Module.register("MMM-PublicTransportBerlin", {
 
         // Cell for direction
         let headerDirection = document.createElement("td");
-        if (this.config.showTableHeadersAsSymbols) {
+        if (this.config.showTableHeadersAsSymbols || this.config.showTableHeadersAs === 'symbol') {
             headerDirection.className = "centeredTd";
             let directionIcon = document.createElement("span");
             directionIcon.className = "fa fa-exchange";
             headerDirection.appendChild(directionIcon);
+        } else if (this.config.showTableHeadersAs==='hidden') {
+            headerDirection.innerHTML = "";
         } else {
             headerDirection.innerHTML = "Nach";
         }

--- a/MMM-PublicTransportBerlin.js
+++ b/MMM-PublicTransportBerlin.js
@@ -16,7 +16,7 @@ Module.register("MMM-PublicTransportBerlin", {
         showColoredLineSymbols: true,       // Want colored line symbols?
         useColorForRealtimeInfo: true,      // Want colored real time information (delay, early)?
         showTableHeadersAsSymbols: true,    // Table Headers as symbols or written?
-        showTableHeadersAs: 'symbol',        // Table headers as symbols, text or hidden
+        showTableHeaders: true,             // Show table headers?
         maxUnreachableDepartures: 3,        // How many unreachable departures should be shown?
         maxReachableDepartures: 7,          // How many reachable departures should be shown?
         fadeUnreachableDepartures: true,
@@ -78,8 +78,6 @@ Module.register("MMM-PublicTransportBerlin", {
             let timeIcon = document.createElement("span");
             timeIcon.className = "fa fa-clock-o";
             headerTime.appendChild(timeIcon);
-        } else if (this.config.showTableHeadersAs==='hidden') {
-            headerTime.innerHTML = "";
         } else {
             headerTime.innerHTML = "Abfahrt";
         }
@@ -98,8 +96,6 @@ Module.register("MMM-PublicTransportBerlin", {
             let lineIcon = document.createElement("span");
             lineIcon.className = "fa fa-tag";
             headerLine.appendChild(lineIcon);
-        } else if (this.config.showTableHeadersAs==='hidden') {
-            headerLine.innerHTML = "";
         } else {
             headerLine.innerHTML = "Linie";
         }
@@ -113,8 +109,6 @@ Module.register("MMM-PublicTransportBerlin", {
             let directionIcon = document.createElement("span");
             directionIcon.className = "fa fa-exchange";
             headerDirection.appendChild(directionIcon);
-        } else if (this.config.showTableHeadersAs==='hidden') {
-            headerDirection.innerHTML = "";
         } else {
             headerDirection.innerHTML = "Nach";
         }
@@ -122,7 +116,10 @@ Module.register("MMM-PublicTransportBerlin", {
         headerRow.appendChild(headerDirection);
 
         headerRow.className = "bold dimmed";
-        tHead.appendChild(headerRow);
+
+        if (this.config.showTableHeaders) {
+            tHead.appendChild(headerRow);
+        }
 
         table.appendChild(tHead);
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The module quite configurable. These are the possible options:
 |`departureMinutes`|For how many minutes in the future should departures be fetched? If `delay` is set > 0, then this time will be added to `now() + delay`. (This could be obsolete in future versions but is needed for now.)<br><br>**Type:** `integer`<br>**Default vaule:** `10`|
 |`showColoredLineSymbols`|If you want the line colored and shaped or text only.<br><br>**Type:** `boolean`<br>**Default vaule:** `true`|
 |`useColorForRealtimeInfo`|Set colors for realtime information<br><br>**Type:** `boolean`<br>**Default vaule:** `true`|
+|`showTableHeaders`|Show or hides the table headers.<br><br>**Type:** `boolean`<br>**Default vaule:** `true`|
 |`showTableHeadersAsSymbols`|Show the table headers as text or symbols.<br><br>**Type:** `boolean`<br>**Default vaule:** `true`|
 |`maxUnreachableDepartures`|How many unreachable departures should be shown. Only necessary, of you set `delay` > 0<br><br>**Type:** `integer`<br>**Default vaule:** `3`|
 |`maxReachableDepartures`|How many reachable departures should be shown. If your `delay = 0`, this is the value for the number of departures you want to see.<br><br>**Type:** `integer`<br>**Default vaule:** `7`|
@@ -91,6 +92,7 @@ Here is an example of an entry in `config.js`:
         marqueeLongDirections: true,
         showColoredLineSymbols: true,  
         useColorForRealtimeInfo: true,
+        showTableHeaders: true,
         showTableHeadersAsSymbols: true,
         maxUnreachableDepartures: 3,    
         maxReachableDepartures: 7,


### PR DESCRIPTION
This PR adds a new option to your module "showTableHeaders" that per default is set to true which changes nothing with regards to the current state of the module. 
When set to false, the table headers (be it symbols or text) are not shown thus giving (at least me) a more cleaned up look (since I know what the table columns mean :-) 
Hope you merge it. Thanks for your work so far!