### PR TITLE
Add translation and css improvements

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -3,7 +3,6 @@
   "plugins": ["stylelint-prettier"],
   "root": true,
   "rules": {
-    "prettier/prettier": true,
-    "selector-class-pattern": null
+    "prettier/prettier": true
   }
 }

--- a/MMM-PublicTransportBerlin.js
+++ b/MMM-PublicTransportBerlin.js
@@ -119,7 +119,7 @@ Module.register("MMM-PublicTransportBerlin", {
 
   async getDom() {
     const wrapper = document.createElement("div");
-    wrapper.className = "ptbWrapper";
+    wrapper.className = "ptb-wrapper";
 
     // Handle loading sequence at init time
     if (this.departuresArray.length === 0 && !this.loaded) {
@@ -141,14 +141,14 @@ Module.register("MMM-PublicTransportBerlin", {
         "FETCHER_ERROR"
       )}: ${JSON.stringify(this.error.message)}<br>`;
       errorContent.innerHTML += this.translate("NO_VBBDATA_ERROR_HINT");
-      errorContent.className = "small light dimmed errorCell";
+      errorContent.className = "small light dimmed ptb-error-cell";
       wrapper.appendChild(errorContent);
       return wrapper;
     }
 
     // The table
     const table = document.createElement("table");
-    table.className = `ptbTable small${
+    table.className = `ptb-table small${
       this.config.useBrightScheme ? "" : " light"
     }`;
 
@@ -215,7 +215,7 @@ Module.register("MMM-PublicTransportBerlin", {
 
     if (this.issueOccurred) {
       const issueDiv = document.createElement("div");
-      issueDiv.className = "ptbIssueDiv";
+      issueDiv.className = "ptb-issue-div";
       issueDiv.innerText = this.translate("CONFIG_ISSUE");
       wrapper.appendChild(issueDiv);
     }
@@ -272,7 +272,7 @@ Module.register("MMM-PublicTransportBerlin", {
 
     const ruleCell = document.createElement("td");
     ruleCell.colSpan = 3;
-    ruleCell.className = "ruleCell";
+    ruleCell.className = "ptb-rule-cell";
     ruleRow.appendChild(ruleCell);
 
     return ruleRow;
@@ -283,7 +283,7 @@ Module.register("MMM-PublicTransportBerlin", {
 
     // Cell for departure time
     const headerTime = document.createElement("td");
-    headerTime.className = "centeredTd";
+    headerTime.className = "ptb-centered-td";
 
     if (this.config.showTableHeadersAsSymbols) {
       const timeIcon = document.createElement("span");
@@ -302,7 +302,7 @@ Module.register("MMM-PublicTransportBerlin", {
 
     // Cell for line symbol
     const headerLine = document.createElement("td");
-    headerLine.className = "centeredTd";
+    headerLine.className = "ptb-centered-td";
 
     if (this.config.showTableHeadersAsSymbols) {
       const lineIcon = document.createElement("span");
@@ -316,7 +316,7 @@ Module.register("MMM-PublicTransportBerlin", {
 
     // Cell for direction
     const headerDirection = document.createElement("td");
-    headerDirection.className = "centeredTd";
+    headerDirection.className = "ptb-centered-td";
 
     if (this.config.showTableHeadersAsSymbols) {
       const directionIcon = document.createElement("span");
@@ -355,14 +355,14 @@ Module.register("MMM-PublicTransportBerlin", {
     const row = document.createElement("tr");
 
     const timeCell = document.createElement("td");
-    timeCell.className = `centeredTd timeCell ${
+    timeCell.className = `ptb-centered-td ptb-time-cell ${
       this.config.useBrightScheme ? " light" : ""
     }`;
     timeCell.innerHTML = currentWhen.format("HH:mm");
     row.appendChild(timeCell);
 
     const delayCell = document.createElement("td");
-    delayCell.className = "delayTimeCell";
+    delayCell.className = "ptb-delay-time-cell";
 
     if (delay > 0) {
       delayCell.innerHTML = `+${delay} `;
@@ -382,7 +382,7 @@ Module.register("MMM-PublicTransportBerlin", {
 
     const lineCell = document.createElement("td");
     const lineSymbol = this.getLineSymbol(currentDeparture);
-    lineCell.className = "centeredTd noPadding lineCell";
+    lineCell.className = "ptb-centered-td ptb-no-padding ptb-line-cell";
 
     lineCell.appendChild(lineSymbol);
     row.appendChild(lineCell);
@@ -396,7 +396,7 @@ Module.register("MMM-PublicTransportBerlin", {
       this.config.marqueeLongDirections &&
       currentDeparture.direction.length >= 26
     ) {
-      directionCell.className = `directionCell marquee${
+      directionCell.className = `ptb-direction-cell ptb-marquee${
         this.config.useBrightScheme ? " bright" : ""
       }`;
       const directionSpan = document.createElement("span");
@@ -410,9 +410,9 @@ Module.register("MMM-PublicTransportBerlin", {
 
     row.appendChild(directionCell);
 
-    // Add cancelled class to this row if the trip was cancelled
+    // Add ptb-cancelled class to this row if the trip was cancelled
     if (currentDeparture.cancelled) {
-      row.classList.add("cancelled");
+      row.classList.add("ptb-cancelled");
     }
 
     return row;

--- a/MMM-PublicTransportBerlin.js
+++ b/MMM-PublicTransportBerlin.js
@@ -216,8 +216,7 @@ Module.register("MMM-PublicTransportBerlin", {
     if (this.issueOccurred) {
       const issueDiv = document.createElement("div");
       issueDiv.className = "ptbIssueDiv";
-      issueDiv.innerText =
-        "⚠️ Config issue. Please check Browser console warnings!";
+      issueDiv.innerText = this.translate("CONFIG_ISSUE");
       wrapper.appendChild(issueDiv);
     }
 

--- a/node_helper.js
+++ b/node_helper.js
@@ -120,32 +120,32 @@ module.exports = NodeHelper.create({
     switch (type) {
       case "suburban":
         colors = lineColors.suburban[name];
-        properties.cssClass = "sbahnsign";
+        properties.cssClass = "ptb-sbahnsign";
         break;
       case "subway":
         colors = lineColors.subway[name];
-        properties.cssClass = "ubahnsign";
+        properties.cssClass = "ptb-ubahnsign";
         break;
       case "bus":
         colors.bg = "#B60079";
         colors.fg = "#FFF";
-        properties.cssClass = "bussign";
+        properties.cssClass = "ptb-bussign";
         break;
       case "tram":
         colors = lineColors.tram[name];
-        properties.cssClass = "tramsign";
+        properties.cssClass = "ptb-tramsign";
         break;
       case "regional":
         colors = lineColors.regional[name];
-        properties.cssClass = "dbsign";
+        properties.cssClass = "ptb-dbsign";
         break;
       case "express":
         if (lineType === "LOCOMORE") {
           colors.bg = "#E5690B";
           colors.fg = "#3E1717";
-          properties.cssClass = "locsign";
+          properties.cssClass = "ptb-locsign";
         } else {
-          properties.cssClass = "expresssign";
+          properties.cssClass = "ptb-expresssign";
         }
         break;
     }

--- a/style.css
+++ b/style.css
@@ -150,3 +150,7 @@
   font-size: var(--font-size-xsmall);
   font-style: italic;
 }
+
+.ptb-issue-div::before {
+  content: "⚠️ ";
+}

--- a/style.css
+++ b/style.css
@@ -64,10 +64,6 @@
   animation: marquee 15s linear infinite;
 }
 
-.marqueeStop {
-  animation-play-state: paused;
-}
-
 @keyframes marquee {
   0% {
     transform: translate(0, 0);
@@ -86,15 +82,6 @@
 
 .noPadding {
   padding: 0;
-}
-
-.ellipsis {
-  position: absolute;
-  background-color: #f414a0;
-  width: 300px;
-  height: 100px;
-  border: 2px;
-  border-radius: 150px;
 }
 
 .sbahnsign {

--- a/style.css
+++ b/style.css
@@ -1,20 +1,20 @@
-.ptbWrapper {
+.ptb-wrapper {
   position: relative;
 }
 
-.ptbTable {
+.ptb-table {
   display: table;
   border-collapse: collapse;
   border-spacing: 1px;
 }
 
-.ruleCell {
+.ptb-rule-cell {
   line-height: 0;
   border-spacing: 10px;
   border-bottom: 1px dotted #666;
 }
 
-.lineCell {
+.ptb-line-cell {
   width: 2.5em;
   height: 1.25em;
   padding-left: 0;
@@ -23,11 +23,11 @@
   margin-right: 0;
 }
 
-.timeCell {
+.ptb-time-cell {
   width: 1em;
 }
 
-.delayTimeCell {
+.ptb-delay-time-cell {
   font-size: 16px;
   padding-left: 3px;
   padding-right: 5px;
@@ -36,35 +36,35 @@
   white-space: nowrap;
 }
 
-.directionCell {
+.ptb-direction-cell {
   max-width: 22ch;
 }
 
-.errorCell {
+.ptb-error-cell {
   max-width: 28ch;
   word-wrap: break-word;
 }
 
-.cancelled {
+.ptb-cancelled {
   text-decoration: line-through;
 }
 
-.marquee {
+.ptb-marquee {
   margin: 0 auto;
   white-space: nowrap;
   overflow: hidden;
   box-sizing: border-box;
 }
 
-.marquee span {
+.ptb-marquee span {
   display: inline-block;
   white-space: nowrap;
   padding-left: 100%;
   text-indent: 0;
-  animation: marquee 15s linear infinite;
+  animation: ptb-marquee 15s linear infinite;
 }
 
-@keyframes marquee {
+@keyframes ptb-marquee {
   0% {
     transform: translate(0, 0);
   }
@@ -74,17 +74,17 @@
   }
 }
 
-.centeredTd {
+.ptb-centered-td {
   display: table-cell;
   text-align: center;
   vertical-align: middle;
 }
 
-.noPadding {
+.ptb-no-padding {
   padding: 0;
 }
 
-.sbahnsign {
+.ptb-sbahnsign {
   color: #fff;
   text-align: center;
   width: 2.5em;
@@ -93,7 +93,7 @@
   border-radius: 1.25em;
 }
 
-.ubahnsign {
+.ptb-ubahnsign {
   color: #fff;
   text-align: center;
   width: 2.5em;
@@ -101,24 +101,7 @@
   position: relative;
 }
 
-.tramsign {
-  color: #fff;
-  text-align: center;
-  width: 2.5em;
-  height: 1.25em;
-  background: #be1414;
-  position: relative;
-}
-
-.bussign {
-  color: #fff;
-  text-align: center;
-  width: 2.5em;
-  height: 1.25em;
-  position: relative;
-}
-
-.dbsign {
+.ptb-tramsign {
   color: #fff;
   text-align: center;
   width: 2.5em;
@@ -127,7 +110,24 @@
   position: relative;
 }
 
-.locsign {
+.ptb-bussign {
+  color: #fff;
+  text-align: center;
+  width: 2.5em;
+  height: 1.25em;
+  position: relative;
+}
+
+.ptb-dbsign {
+  color: #fff;
+  text-align: center;
+  width: 2.5em;
+  height: 1.25em;
+  background: #be1414;
+  position: relative;
+}
+
+.ptb-locsign {
   color: #4b2b1f;
   text-align: center;
   width: 2.5em;
@@ -135,7 +135,7 @@
   position: relative;
 }
 
-.expresssign {
+.ptb-expresssign {
   color: #b4b4b4;
   text-align: center;
   font-style: italic;
@@ -145,7 +145,7 @@
   position: relative;
 }
 
-.ptbIssueDiv {
+.ptb-issue-div {
   color: var(--color-text-dimmed);
   font-size: var(--font-size-xsmall);
   font-style: italic;

--- a/translations/de.json
+++ b/translations/de.json
@@ -5,7 +5,7 @@
   "WHEN": "Abfahrt",
   "LINE": "Linie",
   "NO_VBBDATA_ERROR_HINT": "Das könnte heißen, dass VBB-Daten gerade nicht verfügbar sind.",
-  "FETCHER_ERROR": "Fehler bei Daten abrufen",
+  "FETCHER_ERROR": "Fehler beim Abrufen der Daten.",
   "NO_DEPARTURES_AVAILABLE": "Momentan sind keine Abfahrten von dieser Station vorhanden.",
   "NO_REACHABLE_DEPARTURES": "Keine erreichbaren Abfahrten vorhanden."
 }

--- a/translations/de.json
+++ b/translations/de.json
@@ -1,5 +1,5 @@
 {
-  "CONFIG_ISSUE": "⚠️ Konfigurationsproblem. Bitte überprüfe die Warnungen in der Browserkonsole!",
+  "CONFIG_ISSUE": "Konfigurationsproblem. Bitte überprüfe die Warnungen in der Browserkonsole!",
   "LOADING": "Lade …",
   "DIRECTION": "Richtung",
   "WHEN": "Abfahrt",

--- a/translations/de.json
+++ b/translations/de.json
@@ -1,10 +1,10 @@
 {
+  "CONFIG_ISSUE": "⚠️ Konfigurationsproblem. Bitte überprüfe die Warnungen in der Browserkonsole!",
   "LOADING": "Lade …",
-
   "DIRECTION": "Richtung",
   "WHEN": "Abfahrt",
   "LINE": "Linie",
-  "NO_VBBDATA_ERROR_HINT": "Das k&ouml;nnte hei&szlig;en, dass VBB-Daten gerade nicht verf&uuml;gbar sind.",
+  "NO_VBBDATA_ERROR_HINT": "Das könnte heißen, dass VBB-Daten gerade nicht verfügbar sind.",
   "FETCHER_ERROR": "Fehler bei Daten abrufen",
   "NO_DEPARTURES_AVAILABLE": "Momentan sind keine Abfahrten von dieser Station vorhanden.",
   "NO_REACHABLE_DEPARTURES": "Keine erreichbaren Abfahrten vorhanden."

--- a/translations/en.json
+++ b/translations/en.json
@@ -1,6 +1,6 @@
 {
+  "CONFIG_ISSUE": "⚠️ Config issue. Please check Browser console warnings!",
   "LOADING": "Loading …",
-
   "DIRECTION": "Direction",
   "WHEN": "When",
   "LINE": "Line",

--- a/translations/en.json
+++ b/translations/en.json
@@ -5,7 +5,7 @@
   "WHEN": "When",
   "LINE": "Line",
   "NO_VBBDATA_ERROR_HINT": "This could mean that VBB data is currently not available.",
-  "FETCHER_ERROR": "Error while fetching",
+  "FETCHER_ERROR": "Error while fetching data.",
   "NO_DEPARTURES_AVAILABLE": "There are currently no departures at this station.",
   "NO_REACHABLE_DEPARTURES": "No reachable departures found."
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -1,5 +1,5 @@
 {
-  "CONFIG_ISSUE": "⚠️ Config issue. Please check Browser console warnings!",
+  "CONFIG_ISSUE": "Config issue. Please check Browser console warnings!",
   "LOADING": "Loading …",
   "DIRECTION": "Direction",
   "WHEN": "When",


### PR DESCRIPTION
1. Add german translation for config issue message.
2. Remove encodings for umlauts in translation files (According to my tests, these are not necessary).
3. Remove unused classes `marqueeStop` and `ellipsis` (I can't find any place where they are used).
4. Remove stylelint rule `"selector-class-pattern": null` (to be closer to the standard).
5. Use kebab-case for css classes (to be closer to the standard).
6. Use prefix for all our css classes (to avoid collisions with other modules).