### PR TITLE
Shorten station name in the title as well

### DIFF
--- a/BvgFetcher.js
+++ b/BvgFetcher.js
@@ -26,7 +26,7 @@ module.exports = class BvgFetcher {
 
   async getStationName() {
     const station = await this.hafasClient.stop(this.config.stationId);
-    return station.name;
+    return this.config.shortenStationNames ? shortenStationName(station.name) : station.name;
   }
 
   async getDirectionDescriptor() {


### PR DESCRIPTION
Hi, thanks for your work, I've been using your module for quite some time now and it's great, especially during the strikes atm ;)
I have a very small suggestion for improvement: I think it would make sense that not only the station names for the destination is shortened, but also the station name in the title row. No need to tell me I'm in Berlin again. Before the change, it said for me "Sundgauer Str. (Berlin)". Now it just says "Sundgauer Str." in the title.