### PR TITLE
Maintainance update [v2.1.6]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file. The version
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.6](https://github.com/deg0nz/MMM-PublicTransportBerlin/compare/v2.1.5...v2.1.6) - 2025-04-13 - Maintenance update
+
+- chore: update prepare script message about `husky` for clarity
+- chore: update dependencies
+- chore: resolve new ESLint warning
+
 ## [2.1.5](https://github.com/deg0nz/MMM-PublicTransportBerlin/compare/v2.1.4...v2.1.5) - 2025-03-16 - Maintenance update
 
 - refactor: Replace 'moment' with 'dayjs' for date handling. Reason: ['moment' is considered as legacy](https://momentjs.com/docs/#/-project-status/), 'dayjs' is a modern alternative.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mmm-publictransportberlin",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mmm-publictransportberlin",
-      "version": "2.1.5",
+      "version": "2.1.6",
       "license": "MIT",
       "dependencies": {
         "dayjs": "^1.11.13",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,24 +10,24 @@
       "license": "MIT",
       "dependencies": {
         "dayjs": "^1.11.13",
-        "hafas-client": "^6.3.4",
+        "hafas-client": "^6.3.5",
         "vbb-line-colors": "^1.0.5",
         "vbb-short-station-name": "^1.0.1"
       },
       "devDependencies": {
-        "@eslint/js": "^9.23.0",
+        "@eslint/js": "^9.24.0",
         "@stylistic/eslint-plugin": "^4.2.0",
         "cspell": "^8.18.1",
-        "eslint": "^9.23.0",
+        "eslint": "^9.24.0",
         "eslint-plugin-import-x": "^4.10.0",
         "eslint-plugin-jsonc": "^2.20.0",
         "globals": "^16.0.0",
         "husky": "^9.1.7",
-        "lint-staged": "^15.5.0",
+        "lint-staged": "^15.5.1",
         "markdownlint-cli": "^0.44.0",
         "prettier": "^3.5.3",
-        "stylelint": "^16.17.0",
-        "stylelint-config-standard": "^37.0.0",
+        "stylelint": "^16.18.0",
+        "stylelint-config-standard": "^38.0.0",
         "stylelint-prettier": "^5.0.3"
       },
       "engines": {
@@ -843,9 +843,9 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.2.tgz",
-      "integrity": "sha512-GNKqxfHG2ySmJOBSHg7LxeUx4xpuCoFjacmlCoYWEbaPXLwvfIjixRI12xCQZeULksQb23uiA8F40w5TojpV7w==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.20.0.tgz",
+      "integrity": "sha512-fxlS1kkIjx8+vy2SjuCB94q3htSNrufYTXubwiBFeaQHbH6Ipi43gFJq2zCMt6PHhImH3Xmr0NksKDvchWlpQQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -966,9 +966,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.23.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.23.0.tgz",
-      "integrity": "sha512-35MJ8vCPU0ZMxo7zfev2pypqTwWTofFZO6m4KAtdoFhRpLJUpHTZZ+KB3C7Hb1d7bULYwO4lJXGCi5Se+8OMbw==",
+      "version": "9.24.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.24.0.tgz",
+      "integrity": "sha512-uIY/y3z0uvOGX8cp1C2fiC4+ZmBhp6yZWkojtHL1YEMnRt1Y63HB9TM17proGEmeG7HeUY+UP36F0aknKYTpYA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2602,19 +2602,19 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.23.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.23.0.tgz",
-      "integrity": "sha512-jV7AbNoFPAY1EkFYpLq5bslU9NLNO8xnEeQXwErNibVryjk67wHVmddTBilc5srIttJDBrB0eMHKZBFbSIABCw==",
+      "version": "9.24.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.24.0.tgz",
+      "integrity": "sha512-eh/jxIEJyZrvbWRe4XuVclLPDYSYYYgLy5zXGGxD6j8zjSAxFEzI2fL/8xNq6O2yKqVt+eF2YhV+hxjV6UKXwQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.19.2",
+        "@eslint/config-array": "^0.20.0",
         "@eslint/config-helpers": "^0.2.0",
         "@eslint/core": "^0.12.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.23.0",
+        "@eslint/js": "9.24.0",
         "@eslint/plugin-kit": "^0.2.7",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -3483,9 +3483,9 @@
       "license": "MIT"
     },
     "node_modules/hafas-client": {
-      "version": "6.3.4",
-      "resolved": "https://registry.npmjs.org/hafas-client/-/hafas-client-6.3.4.tgz",
-      "integrity": "sha512-I3T4EeCzErC5M4NDjx+ve6HCBaxbQXEBZD9MIm28LYzGhvhs8mEAalBK5iWHuFQh63Hpw9LfJ7rgP/s2+6rjVQ==",
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/hafas-client/-/hafas-client-6.3.5.tgz",
+      "integrity": "sha512-7TyFYj0ZNJkQqpwxPr22qdrUkxzBGE/x88wCcPAm/fSboP6cGPdWV8f7ExcFqJKQj4LnGQ7/60UEBDWjOKVzaQ==",
       "license": "ISC",
       "dependencies": {
         "@derhuerst/br2nl": "^1.0.0",
@@ -4125,9 +4125,9 @@
       }
     },
     "node_modules/lint-staged": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.5.0.tgz",
-      "integrity": "sha512-WyCzSbfYGhK7cU+UuDDkzUiytbfbi0ZdPy2orwtM75P3WTtQBzmG40cCxIa8Ii2+XjfxzLH6Be46tUfWS85Xfg==",
+      "version": "15.5.1",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.5.1.tgz",
+      "integrity": "sha512-6m7u8mue4Xn6wK6gZvSCQwBvMBR36xfY24nF5bMTf2MHDYG6S3yhJuOgdYVw99hsjyDt2d4z168b3naI8+NWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6146,9 +6146,9 @@
       }
     },
     "node_modules/stylelint": {
-      "version": "16.17.0",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.17.0.tgz",
-      "integrity": "sha512-I9OwVIWRMqVm2Br5iTbrfSqGRPWQUlvm6oXO1xZuYYu0Gpduy67N8wXOZv15p6E/JdlZiAtQaIoLKZEWk5hrjw==",
+      "version": "16.18.0",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.18.0.tgz",
+      "integrity": "sha512-OXb68qzesv7J70BSbFwfK3yTVLEVXiQ/ro6wUE4UrSbKCMjLLA02S8Qq3LC01DxKyVjk7z8xh35aB4JzO3/sNA==",
       "dev": true,
       "funding": [
         {
@@ -6209,9 +6209,9 @@
       }
     },
     "node_modules/stylelint-config-recommended": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-15.0.0.tgz",
-      "integrity": "sha512-9LejMFsat7L+NXttdHdTq94byn25TD+82bzGRiV1Pgasl99pWnwipXS5DguTpp3nP1XjvLXVnEJIuYBfsRjRkA==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-16.0.0.tgz",
+      "integrity": "sha512-4RSmPjQegF34wNcK1e1O3Uz91HN8P1aFdFzio90wNK9mjgAI19u5vsU868cVZboKzCaa5XbpvtTzAAGQAxpcXA==",
       "dev": true,
       "funding": [
         {
@@ -6228,13 +6228,13 @@
         "node": ">=18.12.0"
       },
       "peerDependencies": {
-        "stylelint": "^16.13.0"
+        "stylelint": "^16.16.0"
       }
     },
     "node_modules/stylelint-config-standard": {
-      "version": "37.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-37.0.0.tgz",
-      "integrity": "sha512-+6eBlbSTrOn/il2RlV0zYGQwRTkr+WtzuVSs1reaWGObxnxLpbcspCUYajVQHonVfxVw2U+h42azGhrBvcg8OA==",
+      "version": "38.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-38.0.0.tgz",
+      "integrity": "sha512-uj3JIX+dpFseqd/DJx8Gy3PcRAJhlEZ2IrlFOc4LUxBX/PNMEQ198x7LCOE2Q5oT9Vw8nyc4CIL78xSqPr6iag==",
       "dev": true,
       "funding": [
         {
@@ -6248,13 +6248,13 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "stylelint-config-recommended": "^15.0.0"
+        "stylelint-config-recommended": "^16.0.0"
       },
       "engines": {
         "node": ">=18.12.0"
       },
       "peerDependencies": {
-        "stylelint": "^16.13.0"
+        "stylelint": "^16.18.0"
       }
     },
     "node_modules/stylelint-prettier": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mmm-publictransportberlin",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "description": "Public transport module for MagicMirror² driven by BVG-Hafas data.",
   "keywords": [
     "MagicMirror",

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "test:spelling": "cspell ."
   },
   "dependencies": {
-    "hafas-client": "^6.3.4",
     "dayjs": "^1.11.13",
+    "hafas-client": "^6.3.5",
     "vbb-line-colors": "^1.0.5",
     "vbb-short-station-name": "^1.0.1"
   },
@@ -55,19 +55,19 @@
     ]
   },
   "devDependencies": {
-    "@eslint/js": "^9.23.0",
+    "@eslint/js": "^9.24.0",
     "@stylistic/eslint-plugin": "^4.2.0",
     "cspell": "^8.18.1",
-    "eslint": "^9.23.0",
+    "eslint": "^9.24.0",
     "eslint-plugin-import-x": "^4.10.0",
     "eslint-plugin-jsonc": "^2.20.0",
     "globals": "^16.0.0",
     "husky": "^9.1.7",
-    "lint-staged": "^15.5.0",
+    "lint-staged": "^15.5.1",
     "markdownlint-cli": "^0.44.0",
     "prettier": "^3.5.3",
-    "stylelint": "^16.17.0",
-    "stylelint-config-standard": "^37.0.0",
+    "stylelint": "^16.18.0",
+    "stylelint-config-standard": "^38.0.0",
     "stylelint-prettier": "^5.0.3"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "lint": "eslint && stylelint **/*.css && markdownlint . --ignore node_modules && prettier . --check",
     "lint:fix": "eslint --fix && stylelint **/*.css --fix && markdownlint . --ignore node_modules --fix && prettier . --write",
-    "prepare": "[ -f node_modules/.bin/husky ] && husky || echo husky is not installed.",
+    "prepare": "[ -f node_modules/.bin/husky ] && husky || echo info for developers: husky is not installed.",
     "query": "node ./convenience/query_stations.mjs bvg",
     "test": "npm run lint && npm run test:spelling",
     "test:spelling": "cspell ."


### PR DESCRIPTION
- chore: update prepare script message about `husky` for clarity
- chore: update dependencies
- chore: resolve new ESLint warning

Note: `eslint-plugin-import-x` didn't get updated because `npm run lint` threw an error after it.