### PR TITLE
fix: fix wrongly calculated first reachable departure position

### DIFF
--- a/MMM-PublicTransportBerlin.js
+++ b/MMM-PublicTransportBerlin.js
@@ -416,7 +416,7 @@ Module.register("MMM-PublicTransportBerlin", {
           currentWhen < nowWithDelay &&
           (nextWhen && nextWhen >= nowWithDelay || i === 0 && nextWhen && nextWhen >= nowWithDelay)
         ) {
-          result = i;
+          result = i + 1;
         } else if (i === this.departuresArray.length - 1 && currentWhen < nowWithDelay) {
           throw new Error(this.translate("NO_REACHABLE_DEPARTURES"));
         }


### PR DESCRIPTION
Fixes #351 

Instead of returning the index of the last unreachable Departure, this method now returns the position of the first reachable departure position.